### PR TITLE
 adding "whitout unit coins" tests

### DIFF
--- a/exercises/change/change_test.php
+++ b/exercises/change/change_test.php
@@ -55,4 +55,23 @@ class ChangeTest extends PHPUnit\Framework\TestCase
         $this->expectException('InvalidArgumentException', 'Cannot make change for negative value');
         findFewestCoins(array(1, 2, 5), -5);
     }
+  
+    # bonus point if it pass these tests
+    public function testPossibleChangeWithoutUnitCoinsAvailable()
+    {
+        $this->markTestSkipped();
+        $this->assertEquals(
+            array(2, 2, 2, 5, 10),
+            findFewestCoins(array(2, 5, 10, 20, 50), 21)
+        );
+    }
+
+    public function testAnotherPossibleChangeWithoutUnitCoinsAvailable()
+    {
+        $this->markTestSkipped();
+        $this->assertEquals(
+            array(4, 4, 4, 5, 5, 5),
+            findFewestCoins(array(4, 5), 27)
+        );
+    }
 }


### PR DESCRIPTION
I came to this issue trying to resolve the python version of this exercise. My litteral translation to python of my php implementation was not able to pass these.

For the record, the only php solution i found that can pass these additionnal test is the DiscoParadise's one :
https://exercism.io/tracks/php/exercises/change/solutions/bb24e48efb4847c1be51543bc4742336